### PR TITLE
Fix add per prio stats

### DIFF
--- a/system/stats.cpp
+++ b/system/stats.cpp
@@ -164,8 +164,8 @@ void Stats::print() {
     PerPrioMetrics sum_metrics;
     memset(&sum_metrics, 0, sizeof(PerPrioMetrics));
     for (uint64_t tid = 0; tid < g_thread_cnt; ++tid) {
-      sum_metrics.total_abort_time += _stats[tid]->prio_metrics[p].total_abort_time;
-      sum_metrics.total_exec_time += _stats[tid]->prio_metrics[p].total_exec_time;
+      sum_metrics.total_exec_time_abort += _stats[tid]->prio_metrics[p].total_exec_time_abort;
+      sum_metrics.total_exec_time_commit += _stats[tid]->prio_metrics[p].total_exec_time_commit;
       sum_metrics.total_backoff_time += _stats[tid]->prio_metrics[p].total_backoff_time;
       sum_metrics.total_txn_cnt += _stats[tid]->prio_metrics[p].total_txn_cnt;
       sum_metrics.total_abort_cnt += _stats[tid]->prio_metrics[p].total_abort_cnt;

--- a/system/stats.h
+++ b/system/stats.h
@@ -63,9 +63,9 @@ static_assert(sizeof(LatencyRecord) == 8, "LatencyRecord must be 64-bit");
 
 struct PerPrioMetrics {
   // how long spent on the executions that eventually abort
-  uint64_t total_abort_time;
+  uint64_t total_exec_time_abort;
   // how long spent on the execution that eventually commit
-  uint64_t total_exec_time;
+  uint64_t total_exec_time_commit;
   // how long spent on backoff (abort buffer)
   uint64_t total_backoff_time;
   // how many txns (in this prio) in total
@@ -74,8 +74,8 @@ struct PerPrioMetrics {
   uint64_t total_abort_cnt;
   uint64_t per_abort_cnts[STAT_MAX_NUM_ABORT + 1];
 
-  void add_abort_time(uint64_t t) { total_abort_time += t; }
-  void add_exec_time(uint64_t t) { total_exec_time += t; }
+  void add_exec_time_abort(uint64_t t) { total_exec_time_abort += t; }
+  void add_exec_time_commit(uint64_t t) { total_exec_time_commit += t; }
   void add_backoff_time(uint64_t t) { total_backoff_time += t; }
   void add_txn_cnt(uint64_t cnt) { total_txn_cnt += cnt; }
   void add_abort_cnt(uint64_t abort_cnt) {
@@ -88,8 +88,8 @@ struct PerPrioMetrics {
     std::cout << tag << " ";
     std::cout << "txn_cnt=" << total_txn_cnt << ", ";
     std::cout << "abort_cnt=" << total_abort_cnt << ", ";
-    std::cout << "abort_time=" << total_abort_time << ", ";
-    std::cout << "exec_time=" << total_exec_time << ", ";
+    std::cout << "exec_time_abort=" << total_exec_time_abort << ", ";
+    std::cout << "exec_time_commit=" << total_exec_time_commit << ", ";
     std::cout << "backoff_time=" << total_backoff_time << ", ";
     std::cout << "abort_cnt_distr=[";
     for (int i = 0; i < STAT_MAX_NUM_ABORT; ++i) {

--- a/system/thread.cpp
+++ b/system/thread.cpp
@@ -191,7 +191,7 @@ RC thread_t::run() {
 		}
 
 		ts_t endtime = get_sys_clock();
-		// this is the time of the last execution but includeing sleep if any
+		// this is the time of the last execution but including sleep if any
 		uint64_t timespan = endtime - starttime;
 		// this is the time of the last execution but excluding sleep
 		uint64_t exec_timespan = endtime - exec_start_time;

--- a/system/thread.h
+++ b/system/thread.h
@@ -47,6 +47,7 @@ class thread_t {
         ts_t ready_time;
         base_query * query;
         ts_t starttime;
+        uint64_t exec_time_abort; // exec time that eventually aborts
         uint64_t backoff_time; // accumulated backoff time
     };
     AbortBufferEntry * _abort_buffer;


### PR DESCRIPTION
Previously increment execution time (abort/commit) for every priority immediately after each execution, but the priority of a txn would change if it aborts, so a better accounting should be, we record the time spent in execution and eventually abort, and only add them to the stat when it commits and we know its final priority.

This will eventually produce a figure that breakdown the latency: for a txn that starts with prio=0 and ends with prio=X, how much time it spends (on average) in execution that eventually aborts and how much it spends on the one that commits, as well as how much time spent in backoff.

Other minor change:
1. rename `abort_time` and `exec_time` to `exec_time_abort` and `exec_time_commit`, which explains the purpose better.
2. change the start timestamp of txn execution from the time it actually executes. The previous one uses `starttime` but that may cause it includes sleeping within the abort buffer, so the backoff time and exec_time will overlap.