### PR TITLE
add prio threshold

### DIFF
--- a/config-std.h
+++ b/config-std.h
@@ -120,6 +120,11 @@
 //   whether use fixed priority; if true, a query's priority won't be
 //   incremented no matter how many times it has aborted
 #define SILO_PRIO_FIXED_PRIO        false
+//   don't increment the priority until specific number of aborts. for txns only
+//   aborts 5 times don't contribute to the tail latency, so there is no point
+//   to give these txns priority
+#define SILO_PRIO_ABORT_THRESHOLD_BEFORE_INC_PRIO 8
+//   after num_abort exceeds the threshold, start to increment priority
 //   increment the priority of a query after how many aborts
 //   only effective if SILO_PRIO_FIXED_PRIO is false
 #define SILO_PRIO_INC_PRIO_AFTER_NUM_ABORT 3

--- a/system/stats.cpp
+++ b/system/stats.cpp
@@ -120,6 +120,7 @@ done:
 void Stats::print() {
 #if CC_ALG == SILO_PRIO
   printf("use_fixed_prio: %s\n", SILO_PRIO_FIXED_PRIO ? "true" : "false");
+  printf("abort_threshold_before_inc_prio: %d\n", SILO_PRIO_ABORT_THRESHOLD_BEFORE_INC_PRIO);
   printf("inc_prio_after_num_abort: %d\n", SILO_PRIO_INC_PRIO_AFTER_NUM_ABORT);
 #endif
   ALL_METRICS(INIT_TOTAL_VAR, INIT_TOTAL_VAR, INIT_TOTAL_VAR)

--- a/system/thread.cpp
+++ b/system/thread.cpp
@@ -133,8 +133,14 @@ RC thread_t::run() {
 #if SILO_PRIO_FIXED_PRIO
 		m_txn->prio = m_query->prio;
 #else
-		m_txn->prio = std::min<int>(SILO_PRIO_MAX_PRIO,
-			m_query->prio + (m_query->num_abort / SILO_PRIO_INC_PRIO_AFTER_NUM_ABORT));
+		if (m_query->num_abort <= SILO_PRIO_ABORT_THRESHOLD_BEFORE_INC_PRIO)
+			m_txn->prio = m_query->prio;
+		else
+			m_txn->prio = std::min<int>(
+				SILO_PRIO_MAX_PRIO,
+				m_query->prio + \
+					((m_query->num_abort - SILO_PRIO_ABORT_THRESHOLD_BEFORE_INC_PRIO) / \
+					SILO_PRIO_INC_PRIO_AFTER_NUM_ABORT));
 #endif // SILO_PRIO_FIXED_PRIO
 #else // CC_ALG == SILO_PRIO
 		m_txn->prio = m_query->prio;


### PR DESCRIPTION
Add a threshold: for a given transaction, when the number of aborts is lower than the threshold, do not increment priority after abort; when it is above the threshold, increment the priority after a certain number of aborts.

Setting this threshold to zero is equivalent to the original design.

The motivation for this design is, many transactions only abort a few times, and they don't contribute to the tail latency, so it is not necessary to give them some priority. Empirically, too many high-priority will kill the throughput because they would kill a lot of low-priority transactions.