### PR TITLE
stop execution when txn_cnt reaches threshold

### DIFF
--- a/system/thread.cpp
+++ b/system/thread.cpp
@@ -291,20 +291,23 @@ RC thread_t::run() {
 #if TERMINATE_BY_COUNT
 		if (warmup_finish && txn_cnt >= MAX_TXN_PER_PART) {
 			assert(txn_cnt == MAX_TXN_PER_PART);
-			if( !ATOM_CAS(_wl->sim_done, false, true) )
-				assert( _wl->sim_done);
+			_wl->sim_done.store(true, std::memory_order_release);
 		}
 #else
-		if (warmup_finish && (stats._stats[get_thd_id()]->run_time / 1000000000 >=
-		MAX_RUNTIME)) {
-            if( !ATOM_CAS(_wl->sim_done, false, true) )
-                assert( _wl->sim_done);
+		// even not TERMINATE_BY_COUNT, the execution still must stop when 
+		// txn_cnt >= MAX_TXN_PER_PART; otherwise, it will cause buffer overflow
+		if (warmup_finish && \
+			(stats._stats[get_thd_id()]->run_time >= MAX_RUNTIME * 1000000000 \
+				|| txn_cnt >= MAX_TXN_PER_PART))
+		{
+			assert(txn_cnt <= MAX_TXN_PER_PART);
+			_wl->sim_done.store(true, std::memory_order_release);
 		}
 #endif
 
-		if (_wl->sim_done) {
+		if (_wl->sim_done.load(std::memory_order_acquire)) {
 #if CC_ALG == IC3
-		    m_txn->set_txn_id(get_thd_id() + thd_txn_id * g_thread_cnt);
+			m_txn->set_txn_id(get_thd_id() + thd_txn_id * g_thread_cnt);
 #endif
 			return FINISH;
 		}

--- a/system/wl.cpp
+++ b/system/wl.cpp
@@ -9,7 +9,7 @@
 #include "mem_alloc.h"
 
 RC workload::init() {
-	sim_done = false;
+	sim_done.store(false, std::memory_order_release);
 	return RCOK;
 }
 

--- a/system/wl.h
+++ b/system/wl.h
@@ -37,7 +37,7 @@ public:
 	// ic3 helpers
 	virtual SC_PIECE * get_cedges(TPCCTxnType txn_type, int piece_id); 
 
-	bool sim_done;
+	std::atomic_bool sim_done;
 protected:
 	void index_insert(string index_name, uint64_t key, row_t * row);
 	void index_insert(INDEX * index, uint64_t key, row_t * row, int64_t part_id = -1);


### PR DESCRIPTION
When using time as the termination condition, also stop if already reaching MAX_TXN_PER_PART.